### PR TITLE
chore/remove-docker-compose-version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   server:
     build:


### PR DESCRIPTION
removes docker compose version property as it's [obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)